### PR TITLE
Quotes are still out of sync

### DIFF
--- a/.config/eww/launch_eww
+++ b/.config/eww/launch_eww
@@ -41,6 +41,7 @@ run_eww() {
 if [[ ! -f "$FILE" ]]; then
 	touch "$FILE"
 	run_eww
+  bash $HOME/.config/eww/scripts/quote update
 else
 	${EWW} close-all 
 	rm "$FILE"

--- a/.config/eww/scripts/quote
+++ b/.config/eww/scripts/quote
@@ -1,14 +1,11 @@
 #!/bin/bash
 
+updatequotes() {
 uri=$(curl -s "https://api.quotable.io/random?maxLength=26")
 
 echo $uri | jq '.content' |  cut -d "\"" -f 2 > "$HOME/.cache/eww.quote.x"
 echo $uri | jq '.author' |  cut -d "\"" -f 2 > "$HOME/.cache/eww.author.y"
-
-if [ "$quote" = "" ] ; then
-	quote="Bad programmers worry about the code."
-    author="Linus Torvalds"
-fi
+}
 
 quote=$(cat $HOME/.cache/eww.quote.x)
 author=$(cat $HOME/.cache/eww.author.y)
@@ -24,5 +21,8 @@ echo $quote
 ;;
 author)
 echo "- $author"
+;;
+update)
+  updatequotes
 ;;
 esac


### PR DESCRIPTION
This has same Issue as before 

Bash reads and runs your scripts line by line, so from the top if you're downloading quotes it's gonna run when you get quotes and again when you get author. 
Because even if you're running same script to get quote and author they are running in different instance and treated as different script
I made it into function so it only downloads when you execute that function. and put it in launch script to updates every time the dashboard is launched